### PR TITLE
JSON API

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+type Response struct {
+	Ok      bool        `json:"ok"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}
+
+type SuccessClaim struct {
+	Name    string `json:"name"`
+	PIN     string `json:"pin"`
+	Invoice string `json:"invoice"`
+}
+
+// not authenticated, if correct pin is provided call returns the SuccessClaim
+func ClaimAddress(w http.ResponseWriter, r *http.Request) {
+	params := parseParams(r)
+	pin, inv, err := SaveName(params.Name, params, params.Pin)
+	if err != nil {
+		sendError(w, 400, "could not register name: %s", err.Error())
+		return
+	}
+
+	response := Response{
+		Ok:      true,
+		Message: fmt.Sprintf("claimed %v@%v", params.Name, s.Domain),
+		Data:    SuccessClaim{params.Name, pin, inv},
+	}
+
+	// TODO: middleware for responses that adds this header
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(response)
+}
+
+func GetUser(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	params, err := GetName(name)
+	if err != nil {
+		sendError(w, 400, err.Error())
+		return
+	}
+
+	// add pin to response because sometimes not saved in database; after first call to /api/v1/claim
+	params.Pin = ComputePIN(name)
+
+	response := Response{
+		Ok:      true,
+		Message: fmt.Sprintf("%v@%v found", params.Name, s.Domain),
+		Data:    params,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+func UpdateUser(w http.ResponseWriter, r *http.Request) {
+	params := parseParams(r)
+	name := mux.Vars(r)["name"]
+
+	// if pin not in json request body get it from header
+	if params.Pin == "" {
+		// TODO: work with Context()?
+		params.Pin = r.Header.Get("X-Pin")
+	}
+
+	if _, _, err := SaveName(name, params, params.Pin); err != nil {
+		sendError(w, 500, err.Error())
+		return
+	}
+
+	updatedParams, err := GetName(name)
+	if err != nil {
+		sendError(w, 500, err.Error())
+		return
+	}
+
+	// return the updated values or just http.StatusCreated?
+	response := Response{
+		Ok:      true,
+		Message: fmt.Sprintf("updated %v@%v parameters", params.Name, s.Domain),
+		Data:    updatedParams,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(response)
+}
+
+func DeleteUser(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if err := DeleteName(name); err != nil {
+		sendError(w, 500, err.Error())
+		return
+	}
+
+	response := Response{
+		Ok:      true,
+		Message: fmt.Sprintf("deleted %v@%v", name, s.Domain),
+		Data:    nil,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// authentication middleware
+func authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// exempt /claim from authentication check;
+		if strings.HasPrefix(r.URL.Path, "/api/v1/claim") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		name := mux.Vars(r)["name"]
+		providedPin := r.Header.Get("X-Pin")
+
+		var err error
+
+		if providedPin == "" {
+			err = fmt.Errorf("X-Pin header not provided")
+			// pin should always be passed in header but search in json request body anyways
+			providedPin = parseParams(r).Pin
+		}
+
+		if providedPin != ComputePIN(name) {
+			err = fmt.Errorf("wrong pin")
+		}
+
+		if err != nil {
+			sendError(w, 401, "error fetching user: %s", err.Error())
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// helpers
+func sendError(w http.ResponseWriter, code int, msg string, args ...interface{}) {
+	b, _ := json.Marshal(Response{false, fmt.Sprintf(msg, args...), nil})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(b)
+}
+
+func parseParams(r *http.Request) *Params {
+	reqBody, _ := ioutil.ReadAll(r.Body)
+	var params Params
+	json.Unmarshal(reqBody, &params)
+	return &params
+}

--- a/lnurl.go
+++ b/lnurl.go
@@ -28,11 +28,22 @@ func handleLNURL(w http.ResponseWriter, r *http.Request) {
 		var commentLength int64 = 0
 		// TODO: support webhook comments
 
+		// convert configured sendable amounts to integer
+		minSendable, err := strconv.ParseInt(params.MinSendable, 10, 64)
+		// set defaults
+		if err != nil {
+			minSendable = 1000
+		}
+		maxSendable, err := strconv.ParseInt(params.MaxSendable, 10, 64)
+		if err != nil {
+			maxSendable = 100000000
+		}
+
 		json.NewEncoder(w).Encode(lnurl.LNURLPayResponse1{
 			LNURLResponse:   lnurl.LNURLResponse{Status: "OK"},
 			Callback:        fmt.Sprintf("https://%s/.well-known/lnurlp/%s", s.Domain, username),
-			MinSendable:     1000,
-			MaxSendable:     100000000,
+			MinSendable:     minSendable,
+			MaxSendable:     maxSendable,
 			EncodedMetadata: makeMetadata(params),
 			CommentAllowed:  commentLength,
 			Tag:             "payRequest",

--- a/main.go
+++ b/main.go
@@ -95,6 +95,17 @@ func main() {
 		},
 	)
 
+	api := router.PathPrefix("/api/v1").Subrouter()
+	api.Use(authenticate)
+
+	// unauthenticated
+	api.HandleFunc("/claim", ClaimAddress).Methods("POST")
+
+	// authenticated routes; X-Pin in header or in json request body
+	api.HandleFunc("/users/{name}", GetUser).Methods("GET")
+	api.HandleFunc("/users/{name}", UpdateUser).Methods("PUT")
+	api.HandleFunc("/users/{name}", DeleteUser).Methods("DELETE")
+
 	srv := &http.Server{
 		Handler:      router,
 		Addr:         s.Host + ":" + s.Port,


### PR DESCRIPTION
Small JSON API with POST, GET, PUT and DELETE operations, that allows to programmatically claim, update and delete a  (federated) Lightning Address on a `satdress` server. Down below are some example requests done with `curl`.

Claiming a username:
```bash
curl --request POST \
--url https://satdress.com/api/v1/claim \
--data '{
    "name": "satoshi",
    "kind": "lnd",
    "host": "https://lnd.satdress.com:8080",
    "key": "invoicemacaroonkgCumHVZaeOCS+R",
    "pak": "",
    "waki": "",
    "pin": "",
    "minSendable": "1000",
    "maxSendable": "100000000"
}'
```
Response:
```json
{
    "ok": true,
    "message": "claimed satoshi@satdress.com",
    "data": {
        "name": "satoshi",
        "pin": "49203e7b92a805daf7da74b1a39c0a7b02627c2cce523f4d26742c3539433238",
        "invoice": "lnbc10n1........"
    }
}

```
Authenticated request on an existing user:
```bash
curl --request GET \
--url https://satdress.com/api/v1/users/satoshi \
--header 'X-Pin: 49203e7b92a805daf7da74b1a39c0a7b02627c2cce523f4d26742c3539433238'
```
Response:
```json
{
    "ok": true,
    "message": "satoshi@satdress.com found",
    "data": {
        "name": "satoshi",
        "kind": "lnd",
        "host": "https://lnd.satdress.com:8080",
        "key": "invoicemacaroonkgCumHVZaeOCS+R",
        "pak": "",
        "waki": "",
        "pin": "49203e7b92a805daf7da74b1a39c0a7b02627c2cce523f4d26742c3539433238'",
        "minSendable": "1000",
        "maxSendable": "100000000"
    }
}
```
The `/api/v1/claim` endpoint does not need any authentication (pin) but a `/api/v1/users/{name}` request has to be authenticated through a custom header (`X-Pin`). Would probably be cool to use JWTs here instead and put those in the `Authentication` header but I didn't want to change too much of the existing code base.

This is my first try at writing a JSON API so I'm not sure about if I chose the correct data formats, if the authentication method I used is secure or if there are some other fatal flaws. For that reason I don't expect this to get merged but I would greatly appreciate any kind of feedback (positive or negative). 

What I find interesting about federated Lightning Address servers is that now anyone with a cool domain name could sell/rent out addresses. An API could make it easier to seamlessly integrate that feature into other wallets.