### PR TITLE
Increase maxSendable to 1000000000 mSats

### DIFF
--- a/lnurl.go
+++ b/lnurl.go
@@ -60,7 +60,7 @@ func handleLNURL(w http.ResponseWriter, r *http.Request) {
 		}
 		maxSendable, err := strconv.ParseInt(params.MaxSendable, 10, 64)
 		if err != nil {
-			maxSendable = 100000000
+			maxSendable = 1000000000
 		}
 
 		json.NewEncoder(w).Encode(lnurl.LNURLPayResponse1{


### PR DESCRIPTION
In my opinion maxSendable = 100000000 mSats is to low and discourage widespread use of a lightning address made in satdress. I think 1000000000 = mSats is a good upper limit as that approach the value where an onchain transaction is cheaper.