### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.0-alpine AS builder
+FROM golang:1.20.10-alpine AS builder
 
 WORKDIR /opt/buid
 


### PR DESCRIPTION
The last version doesn't build on golang:1.16.0-alpine, so I upgraded it to 1.20-10-alpine.